### PR TITLE
fixes missing image bug 

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -48,7 +48,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

fixes #1 
adds behaviour to display a placeholder image in item previews and item page if no item image value present.
this avoids broken image being displayed

![image](https://user-images.githubusercontent.com/94173352/207369396-7ede28f7-a268-46d3-849a-55a5db35ebf5.png)
![image](https://user-images.githubusercontent.com/94173352/207369423-a7e3e777-49ce-4e63-81cb-11f1be4ae6a1.png)

