### PR TITLE
added option to display placeholder image when no item image found

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -48,7 +48,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3 broken image displaying if no image url given for an item by using a placeholder image in this case
![image](https://user-images.githubusercontent.com/94173352/207641129-a6eb4535-c6b5-4e2c-90a5-6e7b46ee2c28.png)
![image](https://user-images.githubusercontent.com/94173352/207641153-3ab020a2-cd93-4570-9204-d01d9219c028.png)

