### PR TITLE
add querying items by title

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -52,6 +52,10 @@ router.get("/", auth.optional, function(req, res, next) {
   if (typeof req.query.tag !== "undefined") {
     query.tagList = { $in: [req.query.tag] };
   }
+  
+  if (typeof req.query.title !== "undefined") {
+    query.title = { $regex: req.query.title };
+  }
 
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,


### PR DESCRIPTION
# Description

allows GET request to items route to take a title query which it uses to find only items whose title property contains the query value. Motivation was to facilitate product searching from the UI
